### PR TITLE
Move the website dependencies as devDependency

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,20 +31,20 @@
     "@interop-ui/react-tooltip": "^0.0.1-9",
     "@interop-ui/react-utils": "^0.0.1-9",
     "@modulz/radix-icons": "^3.2.0",
-    "@next/mdx": "^9.5.5",
     "@stitches/react": "0.0.3-canary.4",
-    "framer-motion": "^2.9.4",
-    "next": "9.5.5",
-    "react": "17.0.1",
-    "react-dom": "17.0.1"
+    "framer-motion": "^2.9.4"
   },
   "devDependencies": {
+    "@next/mdx": "^9.5.5",
     "@types/node": "^14.14.2",
     "@types/react": "^16.9.53",
     "husky": ">=4",
     "lint-staged": ">=10",
+    "next": "9.5.5",
     "np": "^6.5.0",
     "prettier": "^2.1.2",
+    "react": "17.0.1",
+    "react-dom": "17.0.1",
     "rollup": "^2.32.1",
     "rollup-plugin-typescript2": "^0.28.0",
     "typescript": "^4.0.3"

--- a/yarn.lock
+++ b/yarn.lock
@@ -60,10 +60,10 @@
   dependencies:
     "@babel/highlight" "^7.10.4"
 
-"@babel/compat-data@^7.11.0", "@babel/compat-data@^7.12.1":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.12.1.tgz#d7386a689aa0ddf06255005b4b991988021101a0"
-  integrity sha512-725AQupWJZ8ba0jbKceeFblZTY90McUBWMwHhkFQ9q1zKPJ95GUktljFcgcsIVwRnTnRKlcYzfiNImg5G9m6ZQ==
+"@babel/compat-data@^7.11.0", "@babel/compat-data@^7.12.5":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/compat-data/-/compat-data-7.12.5.tgz#f56db0c4bb1bbbf221b4e81345aab4141e7cb0e9"
+  integrity sha512-DTsS7cxrsH3by8nqQSpFSyjSfSYl57D6Cf4q8dW3LK83tBKBDCkfcay1nYkXq1nIHXnpX8WMMb/O25HOy3h1zg==
 
 "@babel/core@7.7.7":
   version "7.7.7"
@@ -85,12 +85,12 @@
     semver "^5.4.1"
     source-map "^0.5.0"
 
-"@babel/generator@^7.12.1", "@babel/generator@^7.7.7":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.1.tgz#0d70be32bdaa03d7c51c8597dda76e0df1f15468"
-  integrity sha512-DB+6rafIdc9o72Yc3/Ph5h+6hUjeOp66pF0naQBgUFFuPqzQwIlPTm3xZR7YNvduIMtkDIj2t21LSQwnbCrXvg==
+"@babel/generator@^7.12.5", "@babel/generator@^7.7.7":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/generator/-/generator-7.12.5.tgz#a2c50de5c8b6d708ab95be5e6053936c1884a4de"
+  integrity sha512-m16TQQJ8hPt7E+OS/XVQg/7U184MLXtvuGbCdA7na61vha+ImkyyNM/9DDA0unYCVZn3ZOhng+qz48/KBOT96A==
   dependencies:
-    "@babel/types" "^7.12.1"
+    "@babel/types" "^7.12.5"
     jsesc "^2.5.1"
     source-map "^0.5.0"
 
@@ -127,13 +127,13 @@
     "@babel/types" "^7.10.4"
 
 "@babel/helper-compilation-targets@^7.10.4":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.1.tgz#310e352888fbdbdd8577be8dfdd2afb9e7adcf50"
-  integrity sha512-jtBEif7jsPwP27GPHs06v4WBV0KrE8a/P7n0N0sSvHn2hwUCYnolP/CLmz51IzAW4NlN+HuoBtb9QcwnRo9F/g==
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-compilation-targets/-/helper-compilation-targets-7.12.5.tgz#cb470c76198db6a24e9dbc8987275631e5d29831"
+  integrity sha512-+qH6NrscMolUlzOYngSBMIOQpKUGPPsc61Bu5W10mg84LxZ7cmvnBHzARKbDoFxVvqqAbj6Tg6N7bSrWSPXMyw==
   dependencies:
-    "@babel/compat-data" "^7.12.1"
+    "@babel/compat-data" "^7.12.5"
     "@babel/helper-validator-option" "^7.12.1"
-    browserslist "^4.12.0"
+    browserslist "^4.14.5"
     semver "^5.5.0"
 
 "@babel/helper-create-class-features-plugin@^7.10.4", "@babel/helper-create-class-features-plugin@^7.12.1":
@@ -203,11 +203,11 @@
     "@babel/types" "^7.12.1"
 
 "@babel/helper-module-imports@^7.10.4", "@babel/helper-module-imports@^7.12.1":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.1.tgz#1644c01591a15a2f084dd6d092d9430eb1d1216c"
-  integrity sha512-ZeC1TlMSvikvJNy1v/wPIazCu3NdOwgYZLIkmIyAsGhqkNpiDoQQRmaCK8YP4Pq3GPTLPV9WXaPCJKvx06JxKA==
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-module-imports/-/helper-module-imports-7.12.5.tgz#1bfc0229f794988f76ed0a4d4e90860850b54dfb"
+  integrity sha512-SR713Ogqg6++uexFRORf/+nPXMmWIn80TALu0uaFb+iQIUoR7bOC7zBWyzBs5b3tBBJXuyD0cRu1F15GyzjOWA==
   dependencies:
-    "@babel/types" "^7.12.1"
+    "@babel/types" "^7.12.5"
 
 "@babel/helper-module-transforms@^7.10.4", "@babel/helper-module-transforms@^7.12.1":
   version "7.12.1"
@@ -253,14 +253,14 @@
     "@babel/types" "^7.12.1"
 
 "@babel/helper-replace-supers@^7.12.1":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.12.1.tgz#f15c9cc897439281891e11d5ce12562ac0cf3fa9"
-  integrity sha512-zJjTvtNJnCFsCXVi5rUInstLd/EIVNmIKA1Q9ynESmMBWPWd+7sdR+G4/wdu+Mppfep0XLyG2m7EBPvjCeFyrw==
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/helper-replace-supers/-/helper-replace-supers-7.12.5.tgz#f009a17543bbbbce16b06206ae73b63d3fca68d9"
+  integrity sha512-5YILoed0ZyIpF4gKcpZitEnXEJ9UoDRki1Ey6xz46rxOzfNMAhVIJMoune1hmPVxh40LRv1+oafz7UsWX+vyWA==
   dependencies:
     "@babel/helper-member-expression-to-functions" "^7.12.1"
     "@babel/helper-optimise-call-expression" "^7.10.4"
-    "@babel/traverse" "^7.12.1"
-    "@babel/types" "^7.12.1"
+    "@babel/traverse" "^7.12.5"
+    "@babel/types" "^7.12.5"
 
 "@babel/helper-simple-access@^7.10.4", "@babel/helper-simple-access@^7.12.1":
   version "7.12.1"
@@ -304,13 +304,13 @@
     "@babel/types" "^7.10.4"
 
 "@babel/helpers@^7.7.4":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.12.1.tgz#8a8261c1d438ec18cb890434df4ec768734c1e79"
-  integrity sha512-9JoDSBGoWtmbay98efmT2+mySkwjzeFeAL9BuWNoVQpkPFQF8SIIFUfY5os9u8wVzglzoiPRSW7cuJmBDUt43g==
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/helpers/-/helpers-7.12.5.tgz#1a1ba4a768d9b58310eda516c449913fe647116e"
+  integrity sha512-lgKGMQlKqA8meJqKsW6rUnc4MdUk35Ln0ATDqdM1a/UpARODdI4j5Y5lVfUScnSNkJcdCRAaWkspykNoFg9sJA==
   dependencies:
     "@babel/template" "^7.10.4"
-    "@babel/traverse" "^7.12.1"
-    "@babel/types" "^7.12.1"
+    "@babel/traverse" "^7.12.5"
+    "@babel/types" "^7.12.5"
 
 "@babel/highlight@^7.10.4":
   version "7.10.4"
@@ -321,10 +321,10 @@
     chalk "^2.0.0"
     js-tokens "^4.0.0"
 
-"@babel/parser@^7.10.4", "@babel/parser@^7.12.1", "@babel/parser@^7.7.7":
-  version "7.12.3"
-  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.3.tgz#a305415ebe7a6c7023b40b5122a0662d928334cd"
-  integrity sha512-kFsOS0IbsuhO5ojF8Hc8z/8vEIOkylVBrjiZUbLTE3XFe0Qi+uu6HjzQixkFaqr0ZPAMZcBVxEwmsnsLPZ2Xsw==
+"@babel/parser@^7.10.4", "@babel/parser@^7.12.5", "@babel/parser@^7.7.7":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/parser/-/parser-7.12.5.tgz#b4af32ddd473c0bfa643bd7ff0728b8e71b81ea0"
+  integrity sha512-FVM6RZQ0mn2KCf1VUED7KepYeUWoVShczewOCfm3nzoBybaih51h+sYVVGthW9M6lPByEPTQf+xm27PBdlpwmQ==
 
 "@babel/plugin-proposal-async-generator-functions@^7.10.4":
   version "7.12.1"
@@ -408,9 +408,9 @@
     "@babel/plugin-syntax-numeric-separator" "^7.10.4"
 
 "@babel/plugin-proposal-numeric-separator@^7.10.4":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.1.tgz#0e2c6774c4ce48be412119b4d693ac777f7685a6"
-  integrity sha512-MR7Ok+Af3OhNTCxYVjJZHS0t97ydnJZt/DbR4WISO39iDnhiD8XHrY12xuSJ90FFEGjir0Fzyyn7g/zY6hxbxA==
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-proposal-numeric-separator/-/plugin-proposal-numeric-separator-7.12.5.tgz#b1ce757156d40ed79d59d467cb2b154a5c4149ba"
+  integrity sha512-UiAnkKuOrCyjZ3sYNHlRlfuZJbBHknMQ9VMwVeX97Ofwx7RpD6gS2HfqTCh8KNUQgcOm8IKt103oR4KIjh7Q8g==
   dependencies:
     "@babel/helper-plugin-utils" "^7.10.4"
     "@babel/plugin-syntax-numeric-separator" "^7.10.4"
@@ -780,9 +780,9 @@
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-react-jsx-development@^7.10.4":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.1.tgz#0b8f8cd531dcf7991f1e5f2c10a2a4f1cfc78e36"
-  integrity sha512-IilcGWdN1yNgEGOrB96jbTplRh+V2Pz1EoEwsKsHfX1a/L40cUYuD71Zepa7C+ujv7kJIxnDftWeZbKNEqZjCQ==
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx-development/-/plugin-transform-react-jsx-development-7.12.5.tgz#677de5b96da310430d6cfb7fee16a1603afa3d56"
+  integrity sha512-1JJusg3iPgsZDthyWiCr3KQiGs31ikU/mSf2N2dSYEAO0GEImmVUbWf0VoSDGDFTAn5Dj4DUiR6SdIXHY7tELA==
   dependencies:
     "@babel/helper-builder-react-jsx-experimental" "^7.12.1"
     "@babel/helper-plugin-utils" "^7.10.4"
@@ -803,9 +803,9 @@
     "@babel/helper-plugin-utils" "^7.10.4"
 
 "@babel/plugin-transform-react-jsx@^7.10.4":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.1.tgz#c2d96c77c2b0e4362cc4e77a43ce7c2539d478cb"
-  integrity sha512-RmKejwnT0T0QzQUzcbP5p1VWlpnP8QHtdhEtLG55ZDQnJNalbF3eeDyu3dnGKvGzFIQiBzFhBYTwvv435p9Xpw==
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/plugin-transform-react-jsx/-/plugin-transform-react-jsx-7.12.5.tgz#39ede0e30159770561b6963be143e40af3bde00c"
+  integrity sha512-2xkcPqqrYiOQgSlM/iwto1paPijjsDbUynN13tI6bosDz/jOW3CRzYguIE8wKX32h+msbBM22Dv5fwrFkUOZjQ==
   dependencies:
     "@babel/helper-builder-react-jsx" "^7.10.4"
     "@babel/helper-builder-react-jsx-experimental" "^7.12.1"
@@ -1019,9 +1019,9 @@
     regenerator-runtime "^0.13.4"
 
 "@babel/runtime@^7.8.4":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.1.tgz#b4116a6b6711d010b2dad3b7b6e43bf1b9954740"
-  integrity sha512-J5AIf3vPj3UwXaAzb5j1xM4WAQDX3EMgemF8rjCP3SoW09LfRKAXQKt6CoVYl230P6iWdRcBbnLDDdnqWxZSCA==
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/runtime/-/runtime-7.12.5.tgz#410e7e487441e1b360c29be715d870d9b985882e"
+  integrity sha512-plcc+hbExy3McchJCEQG3knOsuh3HH+Prx1P6cLIkET/0dLuQDEnrT+s27Axgc9bqfsmNUNHfscgMUdBpC9xfg==
   dependencies:
     regenerator-runtime "^0.13.4"
 
@@ -1034,17 +1034,17 @@
     "@babel/parser" "^7.10.4"
     "@babel/types" "^7.10.4"
 
-"@babel/traverse@^7.10.4", "@babel/traverse@^7.12.1", "@babel/traverse@^7.7.4":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.1.tgz#941395e0c5cc86d5d3e75caa095d3924526f0c1e"
-  integrity sha512-MA3WPoRt1ZHo2ZmoGKNqi20YnPt0B1S0GTZEPhhd+hw2KGUzBlHuVunj6K4sNuK+reEvyiPwtp0cpaqLzJDmAw==
+"@babel/traverse@^7.10.4", "@babel/traverse@^7.12.1", "@babel/traverse@^7.12.5", "@babel/traverse@^7.7.4":
+  version "7.12.5"
+  resolved "https://registry.yarnpkg.com/@babel/traverse/-/traverse-7.12.5.tgz#78a0c68c8e8a35e4cacfd31db8bb303d5606f095"
+  integrity sha512-xa15FbQnias7z9a62LwYAA5SZZPkHIXpd42C6uW68o8uTuua96FHZy1y61Va5P/i83FAAcMpW8+A/QayntzuqA==
   dependencies:
     "@babel/code-frame" "^7.10.4"
-    "@babel/generator" "^7.12.1"
+    "@babel/generator" "^7.12.5"
     "@babel/helper-function-name" "^7.10.4"
     "@babel/helper-split-export-declaration" "^7.11.0"
-    "@babel/parser" "^7.12.1"
-    "@babel/types" "^7.12.1"
+    "@babel/parser" "^7.12.5"
+    "@babel/types" "^7.12.5"
     debug "^4.1.0"
     globals "^11.1.0"
     lodash "^4.17.19"
@@ -1067,10 +1067,10 @@
     lodash "^4.17.13"
     to-fast-properties "^2.0.0"
 
-"@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.11.5", "@babel/types@^7.12.1", "@babel/types@^7.4.4", "@babel/types@^7.7.4":
-  version "7.12.1"
-  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.1.tgz#e109d9ab99a8de735be287ee3d6a9947a190c4ae"
-  integrity sha512-BzSY3NJBKM4kyatSOWh3D/JJ2O3CVzBybHWxtgxnggaxEuaSTTDqeiSb/xk9lrkw2Tbqyivw5ZU4rT+EfznQsA==
+"@babel/types@^7.10.4", "@babel/types@^7.10.5", "@babel/types@^7.11.0", "@babel/types@^7.11.5", "@babel/types@^7.12.1", "@babel/types@^7.12.5", "@babel/types@^7.4.4", "@babel/types@^7.7.4":
+  version "7.12.6"
+  resolved "https://registry.yarnpkg.com/@babel/types/-/types-7.12.6.tgz#ae0e55ef1cce1fbc881cd26f8234eb3e657edc96"
+  integrity sha512-hwyjw6GvjBLiyy3W0YQf0Z5Zf4NpYejUnKFcfcUhZCSffoBBp30w6wP2Wn6pk31jMYZvcOrB/1b7cGXvEoKogA==
   dependencies:
     "@babel/helper-validator-identifier" "^7.10.4"
     lodash "^4.17.19"
@@ -1108,240 +1108,225 @@
   resolved "https://registry.yarnpkg.com/@hapi/hoek/-/hoek-9.1.0.tgz#6c9eafc78c1529248f8f4d92b0799a712b6052c6"
   integrity sha512-i9YbZPN3QgfighY/1X1Pu118VUz2Fmmhd6b2n0/O8YVgGGfw0FbUYoA97k7FkpGJ+pLCFEDLUmAPPV4D1kpeFw==
 
-"@interop-ui/popper@0.0.1-9":
-  version "0.0.1-9"
-  resolved "https://registry.yarnpkg.com/@interop-ui/popper/-/popper-0.0.1-9.tgz#b644ff8a56bfd5c08b509a4c008c9acb7c1217ba"
-  integrity sha512-TkKyfFxnY4uvpnIAfrvkmzwr/8UqR8zdCnRcuMVWL9JUU+shvmBgfoL5pDkmGTyIlZbkWJWseEoH00Imy6IPyw==
+"@interop-ui/popper@0.0.1-10":
+  version "0.0.1-10"
+  resolved "https://registry.yarnpkg.com/@interop-ui/popper/-/popper-0.0.1-10.tgz#6d8046458f6ba5aa80a1032abf05e40b3b6af0a9"
+  integrity sha512-PHgRn2ETo0TR6aK7sjvO6JaBjVNqkdHNnvfhEqNAP19kuxEg0hU0RoJj+WuUjhgDfcJTIJeFdYzl3T3YNmj3uA==
   dependencies:
     "@interop-ui/utils" "0.0.1-3"
     csstype "^2.6.11"
 
 "@interop-ui/react-accordion@^0.0.1-10":
-  version "0.0.1-10"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-accordion/-/react-accordion-0.0.1-10.tgz#d9b12e92da5c8c9d38519210d0e390688511eeed"
-  integrity sha512-1WpxmpklicbYOyVua4sIJqR9DMhGyMHIy0BNgoM6Kvi1fzEss20qPho0Jd6qLdKWp/Js2wdUbxwHslLntMj5GQ==
+  version "0.0.1-11"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-accordion/-/react-accordion-0.0.1-11.tgz#cdcea8831be0c1b1226d9ac3564b8198709288e0"
+  integrity sha512-0U1+zLtAIbnYoPuUgbpanqkM97LkBpJsq4FVNUQnIFGpFvvveD62d8XpugJ0HFPReQD1WAgbVAHlWOpXfgPSUA==
   dependencies:
-    "@interop-ui/react-collapsible" "0.0.1-9"
-    "@interop-ui/react-utils" "0.0.1-9"
+    "@interop-ui/react-collapsible" "0.0.1-10"
+    "@interop-ui/react-utils" "0.0.1-10"
     "@interop-ui/utils" "0.0.1-3"
 
 "@interop-ui/react-alert-dialog@^0.0.1-7":
-  version "0.0.1-7"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-alert-dialog/-/react-alert-dialog-0.0.1-7.tgz#997fbe18d0afc86d141660d4498fca8cbb2d12f9"
-  integrity sha512-I5xZlBL0hT78iM5P8DSSjyLNoYaB8r5LzY1HHEGkSuln9LdrLFBnJ7O/aD+WnhuE+hzfyLtEup1rconRF2vCNA==
+  version "0.0.1-8"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-alert-dialog/-/react-alert-dialog-0.0.1-8.tgz#858fa1ed01bbec24248599acc2213fd0e61873c1"
+  integrity sha512-B2gkPUb1tVhwEP0gbDtr6nMqpLdFlWVB5NrGhC1AzJ8RicOinRVL4Z0ire3el0MD5bnbZM/kjKNbR9E9r2n3wg==
   dependencies:
-    "@interop-ui/react-dialog" "0.0.1-9"
-    "@interop-ui/react-utils" "0.0.1-9"
+    "@interop-ui/react-dialog" "0.0.1-10"
+    "@interop-ui/react-utils" "0.0.1-10"
     "@interop-ui/utils" "0.0.1-3"
 
-"@interop-ui/react-arrow@0.0.1-9":
-  version "0.0.1-9"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-arrow/-/react-arrow-0.0.1-9.tgz#cc61ec678d7c64657738563a495371785ec04176"
-  integrity sha512-nrooypUxk+Im6EtIeFfcpltdl5ZcKp/RQLBLXNMKHVRJXUlcT7abBk63yrFz84gkAQyZ47mA4ne2syniBDh6UQ==
+"@interop-ui/react-arrow@0.0.1-10":
+  version "0.0.1-10"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-arrow/-/react-arrow-0.0.1-10.tgz#34f2815d21b7d1f5e5057e33e0ad290712fc14c1"
+  integrity sha512-2/bVfMemPoiBX3dVJshPmufQdbQrFvouSrkK0MenJooLtBF6EveiSGNE+cEoRTiVBcSgx4YzaybuPNOM+IUS7g==
   dependencies:
-    "@interop-ui/react-utils" "0.0.1-9"
+    "@interop-ui/react-utils" "0.0.1-10"
     "@interop-ui/utils" "0.0.1-3"
 
 "@interop-ui/react-avatar@^0.0.1-9":
-  version "0.0.1-9"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-avatar/-/react-avatar-0.0.1-9.tgz#dc1cb847eece8d78cd1d3be02f0bda98589cd479"
-  integrity sha512-kFbGYX5RIpP91d05ZfijMp6dMArWOOc6ETMrZTeY4jk98lF8PgxmgBejwFV/7CqrKXbQP5mXM/QZTnJE5ynooQ==
+  version "0.0.1-10"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-avatar/-/react-avatar-0.0.1-10.tgz#6eca748f3c25b7f5c44e2ebb6f971e4ba13bfed6"
+  integrity sha512-4alIiI3xM3JMTeAFyVktCNVgfl6KwOD4Z3YXBtYENoIfp7kiemn5Sv+rku1iLjuLGlcv+GulcZvtzkwEkEXMXA==
   dependencies:
-    "@interop-ui/react-utils" "0.0.1-9"
+    "@interop-ui/react-utils" "0.0.1-10"
     "@interop-ui/utils" "0.0.1-3"
     "@modulz/radix-icons" "^2.4.1"
 
 "@interop-ui/react-checkbox@^0.0.1-11":
-  version "0.0.1-11"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-checkbox/-/react-checkbox-0.0.1-11.tgz#13c6d312581319f9158eae545598393ef9fd6996"
-  integrity sha512-t6hR3I8uwWgftgmT3ClYeTel1rKweO0T8hSFCGHnymGim+hlZ4NqzSrObHy/TaM4JllNSXAGOMWF+urBU/l0IA==
+  version "0.0.1-12"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-checkbox/-/react-checkbox-0.0.1-12.tgz#3186cfbf32a036109a49edf339858602a79580f2"
+  integrity sha512-2wiJVo5anBBxsUVntHsSIvnKFGqf0yJCbsujwZSxzFT5OaHi8H5Cg11w2AjKCg9E0bB34AXVjnvp9O7xMwCFDw==
   dependencies:
-    "@interop-ui/react-label" "0.0.1-7"
-    "@interop-ui/react-utils" "0.0.1-9"
+    "@interop-ui/react-label" "0.0.1-8"
+    "@interop-ui/react-utils" "0.0.1-10"
     "@interop-ui/utils" "0.0.1-3"
 
-"@interop-ui/react-collapsible@0.0.1-9":
-  version "0.0.1-9"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-collapsible/-/react-collapsible-0.0.1-9.tgz#fc469e6147d21e17bc9596beede36df0eeb3c2ff"
-  integrity sha512-RyFhS3C/g/+NUKfPSBp11FDY6E57Fjrn3ciPZoaGdXAt/ndovmp8z5MI9UNN9x03Qtz+fzF/yp5Y8Feage3obg==
+"@interop-ui/react-collapsible@0.0.1-10":
+  version "0.0.1-10"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-collapsible/-/react-collapsible-0.0.1-10.tgz#8a5fb0c69c903cc96b763eb5359f7d2a7d61540f"
+  integrity sha512-4HU9wi2JtV/dCrhsyTCinlmHRmFDAsPXoTl1yE+sOX/bXP/gH6AT5kwOjTHEqeceiEvKsw2xWfghNAl0YhjQfw==
   dependencies:
-    "@interop-ui/react-utils" "0.0.1-9"
+    "@interop-ui/react-utils" "0.0.1-10"
     "@interop-ui/utils" "0.0.1-3"
 
-"@interop-ui/react-debug-context@0.0.1-8":
-  version "0.0.1-8"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-debug-context/-/react-debug-context-0.0.1-8.tgz#317f1f574d516a60f281e065b6c50ea9d37033e7"
-  integrity sha512-EPMuQ13qQcC6OEflSRpAu5Rbz8v4Xn4k8CHTcPwDb4gOtvkgrnnVGbVqyLA1M39dfF9/W3M4cZAoxyqCUBK5mg==
+"@interop-ui/react-debug-context@0.0.1-10":
+  version "0.0.1-10"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-debug-context/-/react-debug-context-0.0.1-10.tgz#336fd691e22d32e5a45f20cd5eb4c2592a774113"
+  integrity sha512-yVBlVd1jxQbuU1HzzXc1tkF3mXGJIUYlQwMlA7cH9VOZZI4uyZHYyqU8KZOruXm1LNFvyzN1x6wjulwGscvuew==
   dependencies:
-    "@interop-ui/react-utils" "0.0.1-8"
+    "@interop-ui/react-utils" "0.0.1-10"
     "@interop-ui/utils" "0.0.1-3"
 
-"@interop-ui/react-debug-context@0.0.1-9":
-  version "0.0.1-9"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-debug-context/-/react-debug-context-0.0.1-9.tgz#72c5b0f1c575ae1376d139e3989bf5f5adcd69cc"
-  integrity sha512-LugTsNvYNCeROOrhA7YZZg4BsXbHG5AmBwwm5TaM7IMCNQbN5wjLLe74sX2hp9jteHOwriR9t/eg8aD1kcl7WQ==
+"@interop-ui/react-dialog@0.0.1-10", "@interop-ui/react-dialog@^0.0.1-9":
+  version "0.0.1-10"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-dialog/-/react-dialog-0.0.1-10.tgz#e236faaef59a3beaf0c49c9daec7bb3fa2a7bf5f"
+  integrity sha512-jYgZ88G5YYFJIr5gyY4Fwvwh7SfIVFf6KrRY7qtluK/aXFKG1U7hqAFVkfhkdeWyona9vGSWUXVJsmtEoXfWHQ==
   dependencies:
-    "@interop-ui/react-utils" "0.0.1-9"
-    "@interop-ui/utils" "0.0.1-3"
-
-"@interop-ui/react-dialog@0.0.1-9", "@interop-ui/react-dialog@^0.0.1-9":
-  version "0.0.1-9"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-dialog/-/react-dialog-0.0.1-9.tgz#04bffde5130c946c1a5f5eb69b67a3e7220cbee1"
-  integrity sha512-59MQhikvx4V+dUIoVAEGWnzn11kpvgPZYWKQHhZVNluUBdqMTRodFk8EIzCTR0RlSMgyCY2A+aYHS8gCZdDUUA==
-  dependencies:
-    "@interop-ui/react-debug-context" "0.0.1-9"
-    "@interop-ui/react-dismissable-layer" "0.0.1-0"
-    "@interop-ui/react-focus-scope" "0.0.1-0"
-    "@interop-ui/react-portal" "0.0.1-9"
-    "@interop-ui/react-utils" "0.0.1-9"
+    "@interop-ui/react-debug-context" "0.0.1-10"
+    "@interop-ui/react-dismissable-layer" "0.0.1-1"
+    "@interop-ui/react-focus-scope" "0.0.1-1"
+    "@interop-ui/react-portal" "0.0.1-10"
+    "@interop-ui/react-utils" "0.0.1-10"
     "@interop-ui/utils" "0.0.1-3"
     aria-hidden "^1.1.1"
     react-remove-scroll "^2.4.0"
 
-"@interop-ui/react-dismissable-layer@0.0.1-0":
-  version "0.0.1-0"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-dismissable-layer/-/react-dismissable-layer-0.0.1-0.tgz#c75a95aee434504275d29260c2ff31088753a8ea"
-  integrity sha512-/NfOKkFN+5ZnysQwRWgt6sPjNbuZQM8rUmfvjU7kO0HRgApVfoTqzytUuSwn39bMMd4ADRNfY1SEJHay8xOSTw==
+"@interop-ui/react-dismissable-layer@0.0.1-1":
+  version "0.0.1-1"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-dismissable-layer/-/react-dismissable-layer-0.0.1-1.tgz#e589918c7db8ff7d287ec6030648826f4861cf6d"
+  integrity sha512-Oa1Ogjurvk6JJ+h0Cz3UfX9mnSPR5fl9Qa+foI9tUBb6chlF3AD3kPWGM9O4uTOIpXj18nFr0BHlbIo3Zzmzcw==
   dependencies:
-    "@interop-ui/react-debug-context" "0.0.1-8"
-    "@interop-ui/react-utils" "0.0.1-8"
+    "@interop-ui/react-debug-context" "0.0.1-10"
+    "@interop-ui/react-utils" "0.0.1-10"
 
-"@interop-ui/react-focus-scope@0.0.1-0":
-  version "0.0.1-0"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-focus-scope/-/react-focus-scope-0.0.1-0.tgz#1f365c546cb19d4f5ebe3cc0f1cb5d488dfa7855"
-  integrity sha512-fnea5gv7uKSJ8lBgfWUkXVhVeAe2+VrW7D0ASAE8D4gkk0TxMyNRtq9Lb+ZTJOTXskr7qeq/RE62plIi26SXtw==
+"@interop-ui/react-focus-scope@0.0.1-1":
+  version "0.0.1-1"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-focus-scope/-/react-focus-scope-0.0.1-1.tgz#772f5721ff18bf5ef6e01e0f4c14e2816c77a3b7"
+  integrity sha512-fzDo3nfCha7vCdQ1bRnR6iNcrBkEAN45sNls5hhKAy6APOgWmE+dyNI3D+p5lzh4kXJqTJUrT6XAeh8IaFGBhw==
   dependencies:
-    "@interop-ui/react-debug-context" "0.0.1-8"
-    "@interop-ui/react-utils" "0.0.1-8"
+    "@interop-ui/react-debug-context" "0.0.1-10"
+    "@interop-ui/react-utils" "0.0.1-10"
     tabbable "5.0.0"
 
-"@interop-ui/react-label@0.0.1-7":
-  version "0.0.1-7"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-label/-/react-label-0.0.1-7.tgz#9376924524d4cef1a068c8c1ab732a9bc2bd89d6"
-  integrity sha512-QS+FBMNdEu0VIwmmjIy9MJSZ7miI3ejPfkCo3EKyi+n5ExkfrM4l05xqukRgq4SRdxmDDBcILxcPkrjtbzbLBQ==
+"@interop-ui/react-label@0.0.1-8":
+  version "0.0.1-8"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-label/-/react-label-0.0.1-8.tgz#8b415ed31b5f0862f3259af48e4c371902c6b52c"
+  integrity sha512-mTF9x+HmQrCwEPCGr1HCLlHnFhhoPfn+FiivJrx2hfRqerXLc/tVp74EwA4mOQIdW3opC/26LKlFGSH/T1vnhg==
   dependencies:
-    "@interop-ui/react-utils" "0.0.1-9"
+    "@interop-ui/react-utils" "0.0.1-10"
     "@interop-ui/utils" "0.0.1-3"
 
 "@interop-ui/react-popover@^0.0.1-9":
-  version "0.0.1-9"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-popover/-/react-popover-0.0.1-9.tgz#568bc22b3446ea2d492bb4daf220be7fb7744015"
-  integrity sha512-MeSjuhLp97A5DMjV/HRIQNGyAjJxIGCoDqQ1Qw6zjWc+TsV/ac1o+lV/ltrS9DnWu7AeOT7XBWYr2A4bJG12Ug==
+  version "0.0.1-10"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-popover/-/react-popover-0.0.1-10.tgz#11bf51cf5cd2183fdec0ed67eee6f4d75fcddfc3"
+  integrity sha512-5R9tSSQD/ZfnTL+60RS8+c4a1Kg/NE+hxkjrZJx8mdNXcKrakcpU2mh/vnwT1P0zdvKhM3TPthNoP6g3fK8jLw==
   dependencies:
-    "@interop-ui/react-debug-context" "0.0.1-9"
-    "@interop-ui/react-dismissable-layer" "0.0.1-0"
-    "@interop-ui/react-focus-scope" "0.0.1-0"
-    "@interop-ui/react-popper" "0.0.1-8"
-    "@interop-ui/react-portal" "0.0.1-9"
-    "@interop-ui/react-utils" "0.0.1-9"
+    "@interop-ui/react-debug-context" "0.0.1-10"
+    "@interop-ui/react-dismissable-layer" "0.0.1-1"
+    "@interop-ui/react-focus-scope" "0.0.1-1"
+    "@interop-ui/react-popper" "0.0.1-9"
+    "@interop-ui/react-portal" "0.0.1-10"
+    "@interop-ui/react-utils" "0.0.1-10"
     "@interop-ui/utils" "0.0.1-3"
     aria-hidden "^1.1.1"
     react-remove-scroll "^2.4.0"
 
-"@interop-ui/react-popper@0.0.1-8":
-  version "0.0.1-8"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-popper/-/react-popper-0.0.1-8.tgz#1165a81c21ae31ef0271321ee40f23f7bf4901b4"
-  integrity sha512-Sy/os3cgzLWbIz5yZBI1exORFM/QXpU7u4SOJodbFWc0Kqym73mmIUJUESReYxGMl7ewBiwgwmsMiZg1Li+luA==
+"@interop-ui/react-popper@0.0.1-9":
+  version "0.0.1-9"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-popper/-/react-popper-0.0.1-9.tgz#9a8c5726e04e90e4ea7e97a2cb6e60a425783d3a"
+  integrity sha512-pKOS8l702M6cLBwjFdn9gh/XnOI59BWadA0pdHWcKhXTaK5SKRiAw0+5hMtgLS4mfN0pn+VNOfFEyy8BBbZUgw==
   dependencies:
-    "@interop-ui/popper" "0.0.1-9"
-    "@interop-ui/react-arrow" "0.0.1-9"
-    "@interop-ui/react-debug-context" "0.0.1-9"
-    "@interop-ui/react-use-size" "0.0.1-9"
-    "@interop-ui/react-utils" "0.0.1-9"
+    "@interop-ui/popper" "0.0.1-10"
+    "@interop-ui/react-arrow" "0.0.1-10"
+    "@interop-ui/react-debug-context" "0.0.1-10"
+    "@interop-ui/react-use-size" "0.0.1-10"
+    "@interop-ui/react-utils" "0.0.1-10"
     "@interop-ui/utils" "0.0.1-3"
 
-"@interop-ui/react-portal@0.0.1-9":
-  version "0.0.1-9"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-portal/-/react-portal-0.0.1-9.tgz#ec45413e4bdcaa11a752b52e5649e8dafb70920b"
-  integrity sha512-k/PK/3CxMsJ88C/hTcl0vmdQfjyMBRin6gXYAVT57ySFbqHhXfp2Uji6tVCfZLV77qXALIs/+UfV/tTq6Er3JQ==
+"@interop-ui/react-portal@0.0.1-10":
+  version "0.0.1-10"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-portal/-/react-portal-0.0.1-10.tgz#96ac122cb557ce139e24f33b2737673c2f84eda8"
+  integrity sha512-JBByebknmhADAnzArNH8VohjRj2y3y0KKttwT3zdnGOvEid/vFFg9aQUVjrD3rQtA9mtr0X58NA2u/Kc0aSGqg==
   dependencies:
-    "@interop-ui/react-debug-context" "0.0.1-9"
-    "@interop-ui/react-utils" "0.0.1-9"
+    "@interop-ui/react-debug-context" "0.0.1-10"
+    "@interop-ui/react-utils" "0.0.1-10"
     "@interop-ui/utils" "0.0.1-3"
 
 "@interop-ui/react-progress-bar@^0.0.1-7":
-  version "0.0.1-7"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-progress-bar/-/react-progress-bar-0.0.1-7.tgz#fe4fa0ef09258bc70525eed4a48ec09071c1b8e3"
-  integrity sha512-lAjmNw2HhHeNchoFnbAJaqRqoRLfsA3SQXJyd0fLYZbnHzRdSBR+JjXBPkRnfvoir/zEBYCnRF5Bo9vUm4Tw4A==
+  version "0.0.1-8"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-progress-bar/-/react-progress-bar-0.0.1-8.tgz#a3077d1082ce437abcb3ae38e3b7c95fe829a1c9"
+  integrity sha512-sxfk4xvgfBGLhNRxJrLbqUm+PwqDGBenWzybEFvw91JWPx1QHfvmiHrIBszXlg/Y080uiv5Bg8WSkXkVW+2GJQ==
   dependencies:
-    "@interop-ui/react-utils" "0.0.1-9"
+    "@interop-ui/react-utils" "0.0.1-10"
     "@interop-ui/utils" "0.0.1-3"
 
 "@interop-ui/react-separator@^0.0.1-7":
-  version "0.0.1-7"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-separator/-/react-separator-0.0.1-7.tgz#76ae94cc02dc7547c591d237f6aea22254cc1e9e"
-  integrity sha512-9c1RtxUdH+tLkgevMlQQhZlyt6LnOP5Bh6Ib36vXiwqmuvKn1Cv9VcctvqukstRktki4bngrdukil4ngvQD+fw==
+  version "0.0.1-8"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-separator/-/react-separator-0.0.1-8.tgz#6e6cf0c38100b47072b605908b3717dca77dacad"
+  integrity sha512-s5IzBDEVwLrQboJV7mC67S+9+L4OTeMzz+j7NbD2cxulW/4gpc9zP6QismeTsNki7L5Kbn7UpNI/3GVA/S8hYQ==
   dependencies:
-    "@interop-ui/react-utils" "0.0.1-9"
+    "@interop-ui/react-utils" "0.0.1-10"
     "@interop-ui/utils" "0.0.1-3"
 
 "@interop-ui/react-switch@^0.0.1-10":
-  version "0.0.1-10"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-switch/-/react-switch-0.0.1-10.tgz#55ec55ecd919e75287506f083e0cf809583d25fc"
-  integrity sha512-UlxJq0t+ls9/QgMY7oLbldGdemXrZU2hjLG3vRajYrIpQ/iovqk4Did7XdJcqDWTOnOgYuKQNUKoJHtx4uyEEg==
+  version "0.0.1-11"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-switch/-/react-switch-0.0.1-11.tgz#f813de2ac533f4b4f341581668d19a35de8e71aa"
+  integrity sha512-oaXxsjwOtj9LXAp+yUHztO8erCCo1hyjf/35c4QE+To7X1yuIkz2xxkKV9CZTffKOIPawZHrU69r8pPBkkmAeg==
   dependencies:
-    "@interop-ui/react-label" "0.0.1-7"
-    "@interop-ui/react-utils" "0.0.1-9"
+    "@interop-ui/react-label" "0.0.1-8"
+    "@interop-ui/react-utils" "0.0.1-10"
     "@interop-ui/utils" "0.0.1-3"
 
 "@interop-ui/react-tabs@^0.0.1-9":
-  version "0.0.1-9"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-tabs/-/react-tabs-0.0.1-9.tgz#1eb3839500a09aff7bca6f0ef296e0c02a0dd8d2"
-  integrity sha512-D7Ir3OLsN3Z83KS+L5QGFcLSwpQzvwn64dtcif6Kxm/rAK/ushREBddNCww/r/eVGUQEvdSb77yOx6GyF/xB6A==
+  version "0.0.1-10"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-tabs/-/react-tabs-0.0.1-10.tgz#68d7a0b7223756b09d640a49904b110705041f80"
+  integrity sha512-ynqrfYc0nJsbI/F1dwrH9jQD9EAOfswAi4ATBJm15BtGiPuMdhQTehPh0GXLTLpJQt4DrEmt9kAk7dnosPTpog==
   dependencies:
-    "@interop-ui/react-utils" "0.0.1-9"
+    "@interop-ui/react-utils" "0.0.1-10"
     "@interop-ui/utils" "0.0.1-3"
 
 "@interop-ui/react-toggle-button@^0.0.1-10":
-  version "0.0.1-10"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-toggle-button/-/react-toggle-button-0.0.1-10.tgz#a461b7bb35606bba0063cda27f5a864c1de0c2e7"
-  integrity sha512-Hfmc7vjAm7ABKPFUIGjOUM5Ig01YrOPoAfSnML7JQ34c4+a2CaSWxKld/4QDwXmAzf3p6FRdcHPbxoV8XVAxxA==
+  version "0.0.1-11"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-toggle-button/-/react-toggle-button-0.0.1-11.tgz#a1eb7fcf8d47b11e32cf197e40ad6146ade7847b"
+  integrity sha512-UdhVozylA/VJB8rDRUbL4q/G67ZcKNeuinR6etmvaX/zOQQCgSThnKAmyMfPeDGXpSbEMSnGTya/XMvLQMoI+Q==
   dependencies:
-    "@interop-ui/react-utils" "0.0.1-9"
+    "@interop-ui/react-utils" "0.0.1-10"
     "@interop-ui/utils" "0.0.1-3"
 
 "@interop-ui/react-tooltip@^0.0.1-9":
-  version "0.0.1-9"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-tooltip/-/react-tooltip-0.0.1-9.tgz#28ddf1146fe9db70aa7b8af8138c1df4f800fc2f"
-  integrity sha512-mlMZQWPYWuI+a4Q6Cl3hnIc23GSmanY/udz0Y3o/DzAMixO+UduLKECs+OnEIiWF9Y5QJguNOKY9F1Nmc7ilfA==
+  version "0.0.1-10"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-tooltip/-/react-tooltip-0.0.1-10.tgz#cca9406ad90818fc170f1bee0d039dfa08c714f7"
+  integrity sha512-NeHWiRKkdsTIBIBngI64SMNLvg0z2f3rjiOqsUhCghZMRlKTVvE85p7tonAmFYy1MzA5MOLIR5C4Zxl6yfZLkA==
   dependencies:
-    "@interop-ui/popper" "0.0.1-9"
-    "@interop-ui/react-arrow" "0.0.1-9"
-    "@interop-ui/react-popper" "0.0.1-8"
-    "@interop-ui/react-portal" "0.0.1-9"
-    "@interop-ui/react-utils" "0.0.1-9"
-    "@interop-ui/react-visually-hidden" "0.0.1-9"
+    "@interop-ui/popper" "0.0.1-10"
+    "@interop-ui/react-arrow" "0.0.1-10"
+    "@interop-ui/react-popper" "0.0.1-9"
+    "@interop-ui/react-portal" "0.0.1-10"
+    "@interop-ui/react-utils" "0.0.1-10"
+    "@interop-ui/react-visually-hidden" "0.0.1-10"
     "@interop-ui/utils" "0.0.1-3"
 
-"@interop-ui/react-use-size@0.0.1-9":
-  version "0.0.1-9"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-use-size/-/react-use-size-0.0.1-9.tgz#fc59969398e83e5ac60c1d2070fb2787cf85b110"
-  integrity sha512-+DeRuLRSUOHrD+l5rRTYAgMtRzNrd+tDpHzsS0dMybmz0S5Kcnv6J/QrOi1kXsq+QR1LTmwZqG1i3fTNUZqWXg==
+"@interop-ui/react-use-size@0.0.1-10":
+  version "0.0.1-10"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-use-size/-/react-use-size-0.0.1-10.tgz#12a500e6d27f1b427ca1c14b75026d206a37a4b1"
+  integrity sha512-gcgkl85Z4/j6SHztvl7Yok8VWCxj+MGTLfnwgnCAZJdVqqI6CW4fiUiyNe9zks1YhV64vl3dj+vxHJeYiFCJxQ==
   dependencies:
-    "@interop-ui/react-utils" "0.0.1-9"
+    "@interop-ui/react-utils" "0.0.1-10"
     "@interop-ui/utils" "0.0.1-3"
     resize-observer-polyfill "^1.5.1"
 
-"@interop-ui/react-utils@0.0.1-8":
-  version "0.0.1-8"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-utils/-/react-utils-0.0.1-8.tgz#648cf8dc031ed2464010b0678fca7668cfb15499"
-  integrity sha512-AYHwj23En4HFFgVJXjIQNN/td5hphz5UOXxtPiH8ptRa1HX4g7AkPYDpFG2DILBf7wHulkaH6hcqUbo0exlaug==
+"@interop-ui/react-utils@0.0.1-10", "@interop-ui/react-utils@^0.0.1-9":
+  version "0.0.1-10"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-utils/-/react-utils-0.0.1-10.tgz#33280f7541bc67c7c25a418a616f135cff933913"
+  integrity sha512-KORI/2y1omhwBVQ3R7S79ITV80THsDDgB29YXUu7YVTQkv+YymuvZJmq6p9wIlKjN25N75KTnPdhXnrkpxpeAg==
   dependencies:
     "@interop-ui/utils" "0.0.1-3"
 
-"@interop-ui/react-utils@0.0.1-9", "@interop-ui/react-utils@^0.0.1-9":
-  version "0.0.1-9"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-utils/-/react-utils-0.0.1-9.tgz#67650204425bfd7a660a4351e6d292f96be981eb"
-  integrity sha512-ZA8BpPbBrwFTQ15ohyFVg2y2p6fkFtVnM8qBFmCipWreihQmy6UgQ5fq7d7pTgWZlvw0GxZD4HSWRhGtGe1Wrw==
+"@interop-ui/react-visually-hidden@0.0.1-10":
+  version "0.0.1-10"
+  resolved "https://registry.yarnpkg.com/@interop-ui/react-visually-hidden/-/react-visually-hidden-0.0.1-10.tgz#9de5b4db11fae23227508448f82a7e9b0b14cce7"
+  integrity sha512-kQwaN+25OT+o4eIe+wJTM6npK17XmhnsA/0uyP98lcDfqKdAeBRvF1FwOFoclyP3g2CWEmc9U9v7m7HKJtsflA==
   dependencies:
-    "@interop-ui/utils" "0.0.1-3"
-
-"@interop-ui/react-visually-hidden@0.0.1-9":
-  version "0.0.1-9"
-  resolved "https://registry.yarnpkg.com/@interop-ui/react-visually-hidden/-/react-visually-hidden-0.0.1-9.tgz#6b3e5eeb99b0d3f4fc672cffa7a1a953d1ff14ff"
-  integrity sha512-1JQDFSydJMBTEawpkmwzYXT8FZCmZyJagoxJVxjKAhEyFpT8WtMiO9tCIFUaM+7YNoCnneodGh7Dguqy84peMw==
-  dependencies:
-    "@interop-ui/react-utils" "0.0.1-9"
+    "@interop-ui/react-utils" "0.0.1-10"
     "@interop-ui/utils" "0.0.1-3"
 
 "@interop-ui/utils@0.0.1-3":
@@ -1508,9 +1493,9 @@
   integrity sha1-aaI6OtKcrwCX8G7aWbNh7i8GOfY=
 
 "@types/node@*", "@types/node@^14.14.2":
-  version "14.14.2"
-  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.2.tgz#d25295f9e4ca5989a2c610754dc02a9721235eeb"
-  integrity sha512-jeYJU2kl7hL9U5xuI/BhKPZ4vqGM/OmK6whiFAXVhlstzZhVamWhDSmHyGLIp+RVyuF9/d0dqr2P85aFj4BvJg==
+  version "14.14.6"
+  resolved "https://registry.yarnpkg.com/@types/node/-/node-14.14.6.tgz#146d3da57b3c636cc0d1769396ce1cfa8991147f"
+  integrity sha512-6QlRuqsQ/Ox/aJEQWBEJG7A9+u7oSYl3mem/K8IzxXG/kAGbV1YPD9Bg9Zw3vyxC/YP+zONKwy8hGkSt1jxFMw==
 
 "@types/normalize-package-data@^2.4.0":
   version "2.4.0"
@@ -1528,9 +1513,9 @@
   integrity sha512-KfRL3PuHmqQLOG+2tGpRO26Ctg+Cq1E01D2DMriKEATHgWLfeNDmq9e29Q9WIky0dQ3NPkd1mzYH8Lm936Z9qw==
 
 "@types/react@^16.9.53":
-  version "16.9.53"
-  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.53.tgz#40cd4f8b8d6b9528aedd1fff8fcffe7a112a3d23"
-  integrity sha512-4nW60Sd4L7+WMXH1D6jCdVftuW7j4Za6zdp6tJ33Rqv0nk1ZAmQKML9ZLD4H0dehA3FZxXR/GM8gXplf82oNGw==
+  version "16.9.56"
+  resolved "https://registry.yarnpkg.com/@types/react/-/react-16.9.56.tgz#ea25847b53c5bec064933095fc366b1462e2adf0"
+  integrity sha512-gIkl4J44G/qxbuC6r2Xh+D3CGZpJ+NdWTItAPmZbR5mUS+JQ8Zvzpl0ea5qT/ZT3ZNTUcDKUVqV3xBE8wv/DyQ==
   dependencies:
     "@types/prop-types" "*"
     csstype "^3.0.2"
@@ -1721,9 +1706,9 @@ adjust-sourcemap-loader@2.0.0:
     regex-parser "2.2.10"
 
 agent-base@6:
-  version "6.0.1"
-  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.1.tgz#808007e4e5867decb0ab6ab2f928fbdb5a596db4"
-  integrity sha512-01q25QQDwLSsyfhrKbn8yuur+JNw0H+0Y4JiGIKd3z9aYk/w/2kxD/Upc+t2ZBBSUNff50VjPsSW2YxM8QYKVg==
+  version "6.0.2"
+  resolved "https://registry.yarnpkg.com/agent-base/-/agent-base-6.0.2.tgz#49fff58577cfee3f37176feab4c22e00f86d7f77"
+  integrity sha512-RZNwNclF7+MS/8bDg70amg32dyeZGZxiDuQmZxKLAlQjr3jGyLx+4Kkk58UO7D2QdgFIQCovuSuZESne6RG6XQ==
   dependencies:
     debug "4"
 
@@ -2172,15 +2157,15 @@ browserslist@4.13.0:
     escalade "^3.0.1"
     node-releases "^1.1.58"
 
-browserslist@^4.12.0, browserslist@^4.8.5:
-  version "4.14.5"
-  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.14.5.tgz#1c751461a102ddc60e40993639b709be7f2c4015"
-  integrity sha512-Z+vsCZIvCBvqLoYkBFTwEYH3v5MCQbsAjp50ERycpOjnPmolg1Gjy4+KaWWpm8QOJt9GHkhdqAl14NpCX73CWA==
+browserslist@^4.12.0, browserslist@^4.14.5, browserslist@^4.14.6:
+  version "4.14.6"
+  resolved "https://registry.yarnpkg.com/browserslist/-/browserslist-4.14.6.tgz#97702a9c212e0c6b6afefad913d3a1538e348457"
+  integrity sha512-zeFYcUo85ENhc/zxHbiIp0LGzzTrE2Pv2JhxvS7kpUb9Q9D38kUX6Bie7pGutJ/5iF5rOxE7CepAuWD56xJ33A==
   dependencies:
-    caniuse-lite "^1.0.30001135"
-    electron-to-chromium "^1.3.571"
-    escalade "^3.1.0"
-    node-releases "^1.1.61"
+    caniuse-lite "^1.0.30001154"
+    electron-to-chromium "^1.3.585"
+    escalade "^3.1.1"
+    node-releases "^1.1.65"
 
 buffer-from@^1.0.0, buffer-from@^1.1.1:
   version "1.1.1"
@@ -2312,6 +2297,14 @@ cacheable-request@^7.0.1:
     normalize-url "^4.1.0"
     responselike "^2.0.0"
 
+call-bind@^1.0.0:
+  version "1.0.0"
+  resolved "https://registry.yarnpkg.com/call-bind/-/call-bind-1.0.0.tgz#24127054bb3f9bdcb4b1fb82418186072f77b8ce"
+  integrity sha512-AEXsYIyyDY3MCzbwdhzG3Jx1R0J2wetQyUynn6dYHAO+bg8l1k7jwZtRv4ryryFs7EP+NDlikJlVe59jr0cM2w==
+  dependencies:
+    function-bind "^1.1.1"
+    get-intrinsic "^1.0.0"
+
 callsites@^3.0.0:
   version "3.1.0"
   resolved "https://registry.yarnpkg.com/callsites/-/callsites-3.1.0.tgz#b3630abd8943432f54b3f0519238e33cd7df2f73"
@@ -2337,14 +2330,14 @@ camelcase@5.3.1, camelcase@^5.0.0, camelcase@^5.3.1:
   integrity sha512-L28STB170nwWS63UjtlEOE3dldQApaJXZkOI1uMFfzf3rRuPegHaHesyee+YxQ+W6SvRDQV6UrdOdRiR153wJg==
 
 camelcase@^6.0.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.1.0.tgz#27dc176173725fb0adf8a48b647f4d7871944d78"
-  integrity sha512-WCMml9ivU60+8rEJgELlFp1gxFcEGxwYleE3bziHEDeqsqAWGHdimB7beBFGjLzVNgPGyDsfgXLQEYMpmIFnVQ==
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/camelcase/-/camelcase-6.2.0.tgz#924af881c9d525ac9d87f40d964e5cea982a1809"
+  integrity sha512-c7wVvbw3f37nuobQNtgsgG9POC9qMbNuMQmTCqZv23b6MIz0fcYpBiOlv9gEN/hdLdnZTDQhg6e9Dq5M1vKvfg==
 
-caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001113, caniuse-lite@^1.0.30001135:
-  version "1.0.30001150"
-  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001150.tgz#6d0d829da654b0b233576de00335586bc2004df1"
-  integrity sha512-kiNKvihW0m36UhAFnl7bOAv0i1K1f6wpfVtTF5O5O82XzgtBnb05V0XeV3oZ968vfg2sRNChsHw8ASH2hDfoYQ==
+caniuse-lite@^1.0.30001093, caniuse-lite@^1.0.30001113, caniuse-lite@^1.0.30001154:
+  version "1.0.30001157"
+  resolved "https://registry.yarnpkg.com/caniuse-lite/-/caniuse-lite-1.0.30001157.tgz#2d11aaeb239b340bc1aa730eca18a37fdb07a9ab"
+  integrity sha512-gOerH9Wz2IRZ2ZPdMfBvyOi3cjaz4O4dgNwPGzx8EhqAs4+2IL/O+fJsbt+znSigujoZG8bVcIAUM/I/E5K3MA==
 
 chalk@4.0.0:
   version "4.0.0"
@@ -2573,10 +2566,10 @@ commander@^2.20.0:
   resolved "https://registry.yarnpkg.com/commander/-/commander-2.20.3.tgz#fd485e84c03eb4881c20722ba48035e8531aeb33"
   integrity sha512-GpVkmM8vF2vQUkj2LvZmD35JxeJOLCwJ9cUkugyk2nuhbv3+mJvpLYYt+0+USMxE+oj+ey/lJEnhZw75x/OMcQ==
 
-commander@^6.0.0:
-  version "6.1.0"
-  resolved "https://registry.yarnpkg.com/commander/-/commander-6.1.0.tgz#f8d722b78103141006b66f4c7ba1e97315ba75bc"
-  integrity sha512-wl7PNrYWd2y5mp1OK/LhTlv8Ff4kQJQRXXAvF+uU/TPNiVJUxZLRYGj/B0y/lPGAVcSbJqH2Za/cvHmrPMC8mA==
+commander@^6.2.0:
+  version "6.2.0"
+  resolved "https://registry.yarnpkg.com/commander/-/commander-6.2.0.tgz#b990bfb8ac030aedc6d11bc04d1488ffef56db75"
+  integrity sha512-zP4jEKbe8SHzKJYQmq8Y9gYjtO/POJLgIdKgV7B9qNmABVFVc+ctqSX6iXh4mCpJfRBOabiZ2YKPg8ciDw6C+Q==
 
 commondir@^1.0.1:
   version "1.0.1"
@@ -2667,11 +2660,11 @@ copy-descriptor@^0.1.0:
   integrity sha1-Z29us8OZl8LuGsOpJP1hJHSPV40=
 
 core-js-compat@^3.6.2:
-  version "3.6.5"
-  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.6.5.tgz#2a51d9a4e25dfd6e690251aa81f99e3c05481f1c"
-  integrity sha512-7ItTKOhOZbznhXAQ2g/slGg1PJV5zDO/WdkTwi7UEOJmkvsE32PWvx6mKtDjiMpjnR2CNf6BAD6sSxIlv7ptng==
+  version "3.7.0"
+  resolved "https://registry.yarnpkg.com/core-js-compat/-/core-js-compat-3.7.0.tgz#8479c5d3d672d83f1f5ab94cf353e57113e065ed"
+  integrity sha512-V8yBI3+ZLDVomoWICO6kq/CD28Y4r1M7CWeO4AGpMdMfseu8bkSubBmUPySMGKRTS+su4XQ07zUkAsiu9FCWTg==
   dependencies:
-    browserslist "^4.8.5"
+    browserslist "^4.14.6"
     semver "7.0.0"
 
 core-util-is@~1.0.0:
@@ -2852,9 +2845,9 @@ csstype@^2.6.11:
   integrity sha512-ul26pfSQTZW8dcOnD2iiJssfXw0gdNVX9IJDH/X3K5DGPfj+fUYe3kB+swUY6BF3oZDxaID3AJt+9/ojSAE05A==
 
 csstype@^3.0.2:
-  version "3.0.3"
-  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.3.tgz#2b410bbeba38ba9633353aff34b05d9755d065f8"
-  integrity sha512-jPl+wbWPOWJ7SXsWyqGRk3lGecbar0Cb0OvZF/r/ZU011R4YqiRehgkQ9p4eQfo9DSDLqLL3wHwfxeJiuIsNag==
+  version "3.0.4"
+  resolved "https://registry.yarnpkg.com/csstype/-/csstype-3.0.4.tgz#b156d7be03b84ff425c9a0a4b1e5f4da9c5ca888"
+  integrity sha512-xc8DUsCLmjvCfoD7LTGE0ou2MIWLx0K9RCZwSHMOdynqRsP4MtUcLeqh1HcQ2dInwDTqn+3CE0/FZh1et+p4jA==
 
 cyclist@^1.0.1:
   version "1.0.1"
@@ -2881,7 +2874,7 @@ date-fns@^1.27.2:
   resolved "https://registry.yarnpkg.com/date-fns/-/date-fns-1.30.1.tgz#2e71bf0b119153dbb4cc4e88d9ea5acfb50dc05c"
   integrity sha512-hBSVCvSmWC+QypYObzwGOd9wqdDpOt+0wl0KbU+R+uuZBS1jN8VsD1ss3irQDknRj5NvxiTF6oj/nDRnN/UQNw==
 
-debug@4, debug@^4.1.0, debug@^4.1.1:
+debug@4, debug@^4.1.0, debug@^4.2.0:
   version "4.2.0"
   resolved "https://registry.yarnpkg.com/debug/-/debug-4.2.0.tgz#7f150f93920e94c58f5574c2fd01a3110effe7f1"
   integrity sha512-IX2ncY78vDTjZMFUdmsvIRFY2Cf4FnD0wRs+nQwJU8Lu99/tPFdb0VybiiMTPe3I6rQmwsqQqRBvxU+bZ/I8sg==
@@ -3101,10 +3094,10 @@ duplexify@^3.4.2, duplexify@^3.6.0:
     readable-stream "^2.0.0"
     stream-shift "^1.0.0"
 
-electron-to-chromium@^1.3.488, electron-to-chromium@^1.3.571:
-  version "1.3.582"
-  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.582.tgz#1adfac5affce84d85b3d7b3dfbc4ade293a6ffc4"
-  integrity sha512-0nCJ7cSqnkMC+kUuPs0YgklFHraWGl/xHqtZWWtOeVtyi+YqkoAOMGuZQad43DscXCQI/yizcTa3u6B5r+BLww==
+electron-to-chromium@^1.3.488, electron-to-chromium@^1.3.585:
+  version "1.3.591"
+  resolved "https://registry.yarnpkg.com/electron-to-chromium/-/electron-to-chromium-1.3.591.tgz#a18892bf1acb93f7b6e4da402705d564bc235017"
+  integrity sha512-ol/0WzjL4NS4Kqy9VD6xXQON91xIihDT36sYCew/G/bnd1v0/4D+kahp26JauQhgFUjrdva3kRSo7URcUmQ+qw==
 
 elegant-spinner@^1.0.1:
   version "1.0.1"
@@ -3186,33 +3179,6 @@ error-ex@^1.3.1:
   dependencies:
     is-arrayish "^0.2.1"
 
-es-abstract@^1.18.0-next.0, es-abstract@^1.18.0-next.1:
-  version "1.18.0-next.1"
-  resolved "https://registry.yarnpkg.com/es-abstract/-/es-abstract-1.18.0-next.1.tgz#6e3a0a4bda717e5023ab3b8e90bec36108d22c68"
-  integrity sha512-I4UGspA0wpZXWENrdA0uHbnhte683t3qT/1VFH9aX2dA5PPSf6QW5HHXf5HImaqPmjXaVeVk4RGWnaylmV7uAA==
-  dependencies:
-    es-to-primitive "^1.2.1"
-    function-bind "^1.1.1"
-    has "^1.0.3"
-    has-symbols "^1.0.1"
-    is-callable "^1.2.2"
-    is-negative-zero "^2.0.0"
-    is-regex "^1.1.1"
-    object-inspect "^1.8.0"
-    object-keys "^1.1.1"
-    object.assign "^4.1.1"
-    string.prototype.trimend "^1.0.1"
-    string.prototype.trimstart "^1.0.1"
-
-es-to-primitive@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/es-to-primitive/-/es-to-primitive-1.2.1.tgz#e55cd4c9cdc188bcefb03b366c736323fc5c898a"
-  integrity sha512-QCOllgZJtaUo9miYBcLChTUaHNjJF3PYs1VidD7AwiEj1kYxKeQTctLAezAOH5ZKRH0g2IgPn6KwB4IT8iRpvA==
-  dependencies:
-    is-callable "^1.1.4"
-    is-date-object "^1.0.1"
-    is-symbol "^1.0.2"
-
 es5-ext@^0.10.35, es5-ext@^0.10.50:
   version "0.10.53"
   resolved "https://registry.yarnpkg.com/es5-ext/-/es5-ext-0.10.53.tgz#93c5a3acfdbef275220ad72644ad02ee18368de1"
@@ -3239,7 +3205,7 @@ es6-symbol@^3.1.1, es6-symbol@~3.1.3:
     d "^1.0.1"
     ext "^1.1.2"
 
-escalade@^3.0.1, escalade@^3.1.0:
+escalade@^3.0.1, escalade@^3.1.1:
   version "3.1.1"
   resolved "https://registry.yarnpkg.com/escalade/-/escalade-3.1.1.tgz#d8cfdc7000965c5a0174b4a82eaa5c0552742e40"
   integrity sha512-k0er2gUkLf8O0zKJiAhmkTnJlTvINGv7ygDNPbeIsX/TJjGJZHuh9B2UxbsaEkmlEo9MfhrSzmhIlhRlI2GXnw==
@@ -3317,10 +3283,10 @@ evp_bytestokey@^1.0.0, evp_bytestokey@^1.0.3:
     md5.js "^1.3.4"
     safe-buffer "^5.1.1"
 
-execa@^4.0.0, execa@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/execa/-/execa-4.0.3.tgz#0a34dabbad6d66100bd6f2c576c8669403f317f2"
-  integrity sha512-WFDXGHckXPWZX19t1kCsXzOpqX9LWYNqn4C+HqZlk/V0imTkzJZqf87ZBhvpHaftERYknpk0fjSylnXVlVgI0A==
+execa@^4.0.0, execa@^4.1.0:
+  version "4.1.0"
+  resolved "https://registry.yarnpkg.com/execa/-/execa-4.1.0.tgz#4e5491ad1572f2f17a77d388c6c857135b22847a"
+  integrity sha512-j5W0//W7f8UxAn8hXVnwG8tLwdiUy4FJLcSupCg6maBYZDpyBvTApK7KyuI4bKj8KOh1r2YH+6ucuYtJv1bTZA==
   dependencies:
     cross-spawn "^7.0.0"
     get-stream "^5.0.0"
@@ -3585,6 +3551,15 @@ function-bind@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/function-bind/-/function-bind-1.1.1.tgz#a56899d3ea3c9bab874bb9773b7c5ede92f4895d"
   integrity sha512-yIovAzMX49sF8Yl58fSCWJ5svSLuaibPxXQJFLmBObTuCr0Mf1KiPopGM9NiFjiYBCbfaa2Fh6breQ6ANVTI0A==
+
+get-intrinsic@^1.0.0:
+  version "1.0.1"
+  resolved "https://registry.yarnpkg.com/get-intrinsic/-/get-intrinsic-1.0.1.tgz#94a9768fcbdd0595a1c9273aacf4c89d075631be"
+  integrity sha512-ZnWP+AmS1VUaLgTRy47+zKtjTxz+0xMpx3I52i+aalBK1QP19ggLF3Db89KJX7kjfOfP2eoa01qc++GwPgufPg==
+  dependencies:
+    function-bind "^1.1.1"
+    has "^1.0.3"
+    has-symbols "^1.0.1"
 
 get-nonce@^1.0.0:
   version "1.0.1"
@@ -3900,9 +3875,9 @@ icss-utils@^4.0.0, icss-utils@^4.1.1:
     postcss "^7.0.14"
 
 ieee754@^1.1.4:
-  version "1.1.13"
-  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.1.13.tgz#ec168558e95aa181fd87d37f55c32bbcb6708b84"
-  integrity sha512-4vf7I2LYV/HaWerSo3XmlMkp5eZ83i+/CDluXi/IGTs/O1sejBNhTtnxzmRZfvOUqj7lZjqHkeTvpgSFDlWZTg==
+  version "1.2.1"
+  resolved "https://registry.yarnpkg.com/ieee754/-/ieee754-1.2.1.tgz#8eb7a10a63fff25d15a57b001586d177d1b0d352"
+  integrity sha512-dcyqhDvX1C46lXZcVqCpK+FtMRQVdIMN6/Df5js2zouUsqG7I6sFxitIC+7KYK29KdXOLHdu9zL4sFnoVQnqaA==
 
 iferr@^0.1.5:
   version "0.1.5"
@@ -3910,9 +3885,9 @@ iferr@^0.1.5:
   integrity sha1-xg7taebY/bazEEofy8ocGS3FtQE=
 
 import-fresh@^3.1.0, import-fresh@^3.2.1:
-  version "3.2.1"
-  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.1.tgz#633ff618506e793af5ac91bf48b72677e15cbe66"
-  integrity sha512-6e1q1cnWP2RXD9/keSkxHScg508CdXqXWgWBaETNhyuBFz+kUZlKboh+ISK+bU++DmbHimVBrOz/zzPe0sZ3sQ==
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/import-fresh/-/import-fresh-3.2.2.tgz#fc129c160c5d68235507f4331a6baad186bdbc3e"
+  integrity sha512-cTPNrlvJT6twpYy+YmKUKrTSjWFs3bjYjAhCwm+z4EOCubZxAuO+hHpRN64TqjEaYSHs7tJAE0w1CKMGmsG/lw==
   dependencies:
     parent-module "^1.0.0"
     resolve-from "^4.0.0"
@@ -4067,11 +4042,6 @@ is-buffer@^1.1.5:
   resolved "https://registry.yarnpkg.com/is-buffer/-/is-buffer-1.1.6.tgz#efaa2ea9daa0d7ab2ea13a97b2b8ad51fefbe8be"
   integrity sha512-NcdALwpXkTm5Zvvbk7owOUSvVvBKDgKP5/ewfXEznmQFfs4ZRmanOeKBTjRVjka3QFoN6XJ+9F3USqfHqTaU5w==
 
-is-callable@^1.1.4, is-callable@^1.2.2:
-  version "1.2.2"
-  resolved "https://registry.yarnpkg.com/is-callable/-/is-callable-1.2.2.tgz#c7c6715cd22d4ddb48d3e19970223aceabb080d9"
-  integrity sha512-dnMqspv5nU3LoewK2N/y7KLtxtakvTuaCsU9FU50/QDmdbHNy/4/JuRtMHqRU22o3q+W89YQndQEeCVwK+3qrA==
-
 is-ci@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-ci/-/is-ci-2.0.0.tgz#6bc6334181810e04b5c22b3d589fdca55026404c"
@@ -4080,9 +4050,9 @@ is-ci@^2.0.0:
     ci-info "^2.0.0"
 
 is-core-module@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.0.0.tgz#58531b70aed1db7c0e8d4eb1a0a2d1ddd64bd12d"
-  integrity sha512-jq1AH6C8MuteOoBPwkxHafmByhL9j5q4OaPGdbuD+ZtQJVzH+i6E3BJDQcBA09k57i2Hh2yQbEG8yObZ0jdlWw==
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/is-core-module/-/is-core-module-2.1.0.tgz#a4cc031d9b1aca63eecbd18a650e13cb4eeab946"
+  integrity sha512-YcV7BgVMRFRua2FqQzKtTDMz8iCuLEyGKjr70q8Zm1yy2qKcurbFEd79PAdHV77oL3NrAaOVQIbMmiHQCHB7ZA==
   dependencies:
     has "^1.0.3"
 
@@ -4099,11 +4069,6 @@ is-data-descriptor@^1.0.0:
   integrity sha512-jbRXy1FmtAoCjQkVmIVYwuuqDFUbaOeDjmed1tOGPrsMhtJA4rD9tkgA0F1qJ3gRFRXcHYVkdeaP50Q5rE/jLQ==
   dependencies:
     kind-of "^6.0.0"
-
-is-date-object@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/is-date-object/-/is-date-object-1.0.2.tgz#bda736f2cd8fd06d32844e7743bfa7494c3bfd7e"
-  integrity sha512-USlDT524woQ08aoZFzh3/Z6ch9Y/EWXEHQ/AaRN0SkKq4t2Jw2R2339tSXmwuVoY7LLlBCbOIlx2myP/L5zk0g==
 
 is-descriptor@^0.1.0:
   version "0.1.6"
@@ -4184,11 +4149,6 @@ is-installed-globally@^0.3.1:
     global-dirs "^2.0.1"
     is-path-inside "^3.0.1"
 
-is-negative-zero@^2.0.0:
-  version "2.0.0"
-  resolved "https://registry.yarnpkg.com/is-negative-zero/-/is-negative-zero-2.0.0.tgz#9553b121b0fac28869da9ed459e20c7543788461"
-  integrity sha1-lVOxIbD6wohp2p7UWeIMdUN4hGE=
-
 is-npm@^4.0.0:
   version "4.0.0"
   resolved "https://registry.yarnpkg.com/is-npm/-/is-npm-4.0.0.tgz#c90dd8380696df87a7a6d823c20d0b12bbe3c84d"
@@ -4264,13 +4224,6 @@ is-promise@^2.1.0:
   resolved "https://registry.yarnpkg.com/is-promise/-/is-promise-2.2.2.tgz#39ab959ccbf9a774cf079f7b40c7a26f763135f1"
   integrity sha512-+lP4/6lKUBfQjZ2pdxThZvLUAafmZb8OAxFb8XXtiQmS35INgr85hdOGoEs124ez1FCnZJt6jau/T+alh58QFQ==
 
-is-regex@^1.1.1:
-  version "1.1.1"
-  resolved "https://registry.yarnpkg.com/is-regex/-/is-regex-1.1.1.tgz#c6f98aacc546f6cec5468a07b7b153ab564a57b9"
-  integrity sha512-1+QkEcxiLlB7VEyFtyBg94e08OAsvq7FUBgApTq/w2ymCLyKJgDPsybBENVtA7XCQEgEXxKPonG+mvYRxh/LIg==
-  dependencies:
-    has-symbols "^1.0.1"
-
 is-regexp@^1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/is-regexp/-/is-regexp-1.0.0.tgz#fd2d883545c46bac5a633e7b9a09e87fa2cb5069"
@@ -4292,13 +4245,6 @@ is-stream@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/is-stream/-/is-stream-2.0.0.tgz#bde9c32680d6fae04129d6ac9d921ce7815f78e3"
   integrity sha512-XCoy+WlUr7d1+Z8GgSuXmpuUFC9fOhRXglJMx+dwLKTkL44Cjd4W1Z5P+BQZpr+cR93aGP4S/s7Ftw6Nd/kiEw==
-
-is-symbol@^1.0.2:
-  version "1.0.3"
-  resolved "https://registry.yarnpkg.com/is-symbol/-/is-symbol-1.0.3.tgz#38e1014b9e6329be0de9d24a414fd7441ec61937"
-  integrity sha512-OwijhaRSgqvhm/0ZdAcXNZt9lYdKFpcRDT5ULUuYXPoT794UNOdU+gpT6Rzo7b4V2HUl/op6GqY894AZwv9faQ==
-  dependencies:
-    has-symbols "^1.0.1"
 
 is-typedarray@^1.0.0:
   version "1.0.0"
@@ -4496,19 +4442,19 @@ lines-and-columns@^1.1.6:
   integrity sha1-HADHQ7QzzQpOgHWPe2SldEDZ/wA=
 
 lint-staged@>=10:
-  version "10.4.2"
-  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.4.2.tgz#9fee4635c4b5ddb845746f237c6d43494ccd21c1"
-  integrity sha512-OLCA9K1hS+Sl179SO6kX0JtnsaKj/MZalEhUj5yAgXsb63qPI/Gfn6Ua1KuZdbfkZNEu3/n5C/obYCu70IMt9g==
+  version "10.5.1"
+  resolved "https://registry.yarnpkg.com/lint-staged/-/lint-staged-10.5.1.tgz#901e915c2360072dded0e7d752a0d9a49e079daa"
+  integrity sha512-fTkTGFtwFIJJzn/PbUO3RXyEBHIhbfYBE7+rJyLcOXabViaO/h6OslgeK6zpeUtzkDrzkgyAYDTLAwx6JzDTHw==
   dependencies:
     chalk "^4.1.0"
     cli-truncate "^2.1.0"
-    commander "^6.0.0"
+    commander "^6.2.0"
     cosmiconfig "^7.0.0"
-    debug "^4.1.1"
+    debug "^4.2.0"
     dedent "^0.7.0"
     enquirer "^2.3.6"
-    execa "^4.0.3"
-    listr2 "^2.6.0"
+    execa "^4.1.0"
+    listr2 "^3.2.2"
     log-symbols "^4.0.0"
     micromatch "^4.0.2"
     normalize-path "^3.0.0"
@@ -4555,10 +4501,10 @@ listr-verbose-renderer@^0.5.0:
     date-fns "^1.27.2"
     figures "^2.0.0"
 
-listr2@^2.6.0:
-  version "2.6.2"
-  resolved "https://registry.yarnpkg.com/listr2/-/listr2-2.6.2.tgz#4912eb01e1e2dd72ec37f3895a56bf2622d6f36a"
-  integrity sha512-6x6pKEMs8DSIpA/tixiYY2m/GcbgMplMVmhQAaLFxEtNSKLeWTGjtmU57xvv6QCm2XcqzyNXL/cTSVf4IChCRA==
+listr2@^3.2.2:
+  version "3.2.2"
+  resolved "https://registry.yarnpkg.com/listr2/-/listr2-3.2.2.tgz#d20feb75015e506992b55af40722ba1af168b8f1"
+  integrity sha512-AajqcZEUikF2ioph6PfH3dIuxJclhr3i3kHgTOP0xeXdWQohrvJAAmqVcV43/GI987HFY/vzT73jYXoa4esDHg==
   dependencies:
     chalk "^4.1.0"
     cli-truncate "^2.1.0"
@@ -4566,7 +4512,7 @@ listr2@^2.6.0:
     indent-string "^4.0.0"
     log-update "^4.0.0"
     p-map "^4.0.0"
-    rxjs "^6.6.2"
+    rxjs "^6.6.3"
     through "^2.3.8"
 
 listr@^0.14.3:
@@ -5157,9 +5103,9 @@ node-fetch@2.6.1:
   integrity sha512-V4aYg89jEoVRxRb2fJdAg8FHvI7cEyYdVAh94HH0UIK8oJxUfkjlDQN9RbMx+bEjP7+ggMiFRprSti032Oipxw==
 
 node-html-parser@^1.2.19:
-  version "1.3.1"
-  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-1.3.1.tgz#f58e55a029b51deae8924312be9817ef5cf5ed96"
-  integrity sha512-AwYVI6GyEKj9NGoyMfSx4j5l7Axf7obQgLWGxtasLjED6RggTTQoq5ZRzjwSUfgSZ+Mv8Nzbi3pID0gFGqNUsA==
+  version "1.4.9"
+  resolved "https://registry.yarnpkg.com/node-html-parser/-/node-html-parser-1.4.9.tgz#3c8f6cac46479fae5800725edb532e9ae8fd816c"
+  integrity sha512-UVcirFD1Bn0O+TSmloHeHqZZCxHjvtIeGdVdGMhyZ8/PWlEiZaZ5iJzR189yKZr8p0FXN58BUeC7RHRkf/KYGw==
   dependencies:
     he "1.2.0"
 
@@ -5192,10 +5138,10 @@ node-libs-browser@^2.2.1:
     util "^0.11.0"
     vm-browserify "^1.0.1"
 
-node-releases@^1.1.58, node-releases@^1.1.61:
-  version "1.1.64"
-  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.64.tgz#71b4ae988e9b1dd7c1ffce58dd9e561752dfebc5"
-  integrity sha512-Iec8O9166/x2HRMJyLLLWkd0sFFLrFNy+Xf+JQfSQsdBJzPcHpNl3JQ9gD4j+aJxmCa25jNsIbM4bmACtSbkSg==
+node-releases@^1.1.58, node-releases@^1.1.65:
+  version "1.1.66"
+  resolved "https://registry.yarnpkg.com/node-releases/-/node-releases-1.1.66.tgz#609bd0dc069381015cd982300bae51ab4f1b1814"
+  integrity sha512-JHEQ1iWPGK+38VLB2H9ef2otU4l8s3yAMt9Xf934r6+ojCYDMHPMqvCc9TnzfeFSP1QEOeU6YZEd3+De0LTCgg==
 
 normalize-html-whitespace@1.0.0:
   version "1.0.0"
@@ -5311,11 +5257,6 @@ object-copy@^0.1.0:
     define-property "^0.2.5"
     kind-of "^3.0.3"
 
-object-inspect@^1.8.0:
-  version "1.8.0"
-  resolved "https://registry.yarnpkg.com/object-inspect/-/object-inspect-1.8.0.tgz#df807e5ecf53a609cc6bfe93eac3cc7be5b3a9d0"
-  integrity sha512-jLdtEOB112fORuypAyl/50VRVIBIdVQOSUUGQHzJ4xBSbit81zRarz7GThkEFZy1RceYrWYcPcBFPQwHyAc1gA==
-
 object-keys@^1.0.12, object-keys@^1.1.1:
   version "1.1.1"
   resolved "https://registry.yarnpkg.com/object-keys/-/object-keys-1.1.1.tgz#1c47f272df277f3b1daf061677d9c82e2322c60e"
@@ -5333,13 +5274,13 @@ object-visit@^1.0.0:
   dependencies:
     isobject "^3.0.0"
 
-object.assign@^4.1.0, object.assign@^4.1.1:
-  version "4.1.1"
-  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.1.tgz#303867a666cdd41936ecdedfb1f8f3e32a478cdd"
-  integrity sha512-VT/cxmx5yaoHSOTSyrCygIDFco+RsibY2NM0a4RdEeY/4KgqezwFtK1yr3U67xYhqJSlASm2pKhLVzPj2lr4bA==
+object.assign@^4.1.0:
+  version "4.1.2"
+  resolved "https://registry.yarnpkg.com/object.assign/-/object.assign-4.1.2.tgz#0ed54a342eceb37b38ff76eb831a0e788cb63940"
+  integrity sha512-ixT2L5THXsApyiUPYKmW+2EHpXXe5Ii3M+f4e+aJFAHao5amFRW6J0OO6c/LU8Be47utCx2GL89hxGB6XSmKuQ==
   dependencies:
+    call-bind "^1.0.0"
     define-properties "^1.1.3"
-    es-abstract "^1.18.0-next.0"
     has-symbols "^1.0.1"
     object-keys "^1.1.1"
 
@@ -5865,9 +5806,9 @@ punycode@^2.1.0:
   integrity sha512-XRsRjdf+j5ml+y/6GKHPZbrF/8p2Yga0JPtdqTIY2Xe5ohJPD9saDJJLPvp9+NSBprVvevdXZybnj2cv8OEd0A==
 
 pupa@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/pupa/-/pupa-2.1.0.tgz#9e4ec587952b5e4f2c06fe577b0e7db97e8ef721"
-  integrity sha512-Pj8EhJzFiPwnf4dEXpuUWwH8M/Yl4vpl4cN2RX1i3R77DWvbY5ZPKni7CCKkOYxz+XKt2fieemsV+WTZbIlYzg==
+  version "2.1.1"
+  resolved "https://registry.yarnpkg.com/pupa/-/pupa-2.1.1.tgz#f5e8fd4afc2c5d97828faa523549ed8744a20d62"
+  integrity sha512-l1jNAspIBSFqbT+y+5FosojNpVpF94nlI+wDUpqP9enwOTfHx9f0gh5nB96vl+6yTpsJsypeNrwfzPrKuHB41A==
   dependencies:
     escape-goat "^2.0.0"
 
@@ -6039,9 +5980,9 @@ regenerate-unicode-properties@^8.2.0:
     regenerate "^1.4.0"
 
 regenerate@^1.4.0:
-  version "1.4.1"
-  resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.1.tgz#cad92ad8e6b591773485fbe05a485caf4f457e6f"
-  integrity sha512-j2+C8+NtXQgEKWk49MMP5P/u2GhnahTtVkRIHr5R5lVRlbKvmQ+oS+A5aLKWp2ma5VkT8sh6v+v4hbH0YHR66A==
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/regenerate/-/regenerate-1.4.2.tgz#b9346d8827e8f5a32f7ba29637d398b69014848a"
+  integrity sha512-zrceR/XhGYU/d/opr2EKO7aRHUeiBI8qjtfHqADTwZd6Szfy16la6kqD0MIUs5z5hx6AaKa+PixpPrR289+I0A==
 
 regenerator-runtime@^0.13.4:
   version "0.13.7"
@@ -6249,9 +6190,9 @@ rollup-plugin-typescript2@^0.28.0:
     tslib "2.0.1"
 
 rollup@^2.32.1:
-  version "2.32.1"
-  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.32.1.tgz#625a92c54f5b4d28ada12d618641491d4dbb548c"
-  integrity sha512-Op2vWTpvK7t6/Qnm1TTh7VjEZZkN8RWgf0DHbkKzQBwNf748YhXbozHVefqpPp/Fuyk/PQPAnYsBxAEtlMvpUw==
+  version "2.33.1"
+  resolved "https://registry.yarnpkg.com/rollup/-/rollup-2.33.1.tgz#802795164164ee63cd47769d8879c33ec8ae0c40"
+  integrity sha512-uY4O/IoL9oNW8MMcbA5hcOaz6tZTMIh7qJHx/tzIJm+n1wLoY38BLn6fuy7DhR57oNFLMbDQtDeJoFURt5933w==
   optionalDependencies:
     fsevents "~2.1.2"
 
@@ -6267,7 +6208,7 @@ run-queue@^1.0.0, run-queue@^1.0.3:
   dependencies:
     aproba "^1.1.1"
 
-rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.5.4, rxjs@^6.6.0, rxjs@^6.6.2:
+rxjs@^6.3.3, rxjs@^6.4.0, rxjs@^6.5.3, rxjs@^6.5.4, rxjs@^6.6.0, rxjs@^6.6.3:
   version "6.6.3"
   resolved "https://registry.yarnpkg.com/rxjs/-/rxjs-6.6.3.tgz#8ca84635c4daa900c0d3967a6ee7ac60271ee552"
   integrity sha512-trsQc+xYYXZ3urjOiJOuCOa5N3jAZ3eiSpQB5hIT8zGlL2QfnHLJ2r7GMkBGuIausdJN1OneaI6gQlsqNHHmZQ==
@@ -6690,22 +6631,6 @@ string-width@^4.0.0, string-width@^4.1.0, string-width@^4.2.0:
     is-fullwidth-code-point "^3.0.0"
     strip-ansi "^6.0.0"
 
-string.prototype.trimend@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimend/-/string.prototype.trimend-1.0.2.tgz#6ddd9a8796bc714b489a3ae22246a208f37bfa46"
-  integrity sha512-8oAG/hi14Z4nOVP0z6mdiVZ/wqjDtWSLygMigTzAb+7aPEDTleeFf+WrF+alzecxIRkckkJVn+dTlwzJXORATw==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.18.0-next.1"
-
-string.prototype.trimstart@^1.0.1:
-  version "1.0.2"
-  resolved "https://registry.yarnpkg.com/string.prototype.trimstart/-/string.prototype.trimstart-1.0.2.tgz#22d45da81015309cd0cdd79787e8919fc5c613e7"
-  integrity sha512-7F6CdBTl5zyu30BJFdzSTlSlLPwODC23Od+iLoVH8X6+3fvDPPuBVVj9iaB1GOsSTSIgVfsfm27R2FGrAPznWg==
-  dependencies:
-    define-properties "^1.1.3"
-    es-abstract "^1.18.0-next.1"
-
 string_decoder@^1.0.0, string_decoder@^1.1.1:
   version "1.3.0"
   resolved "https://registry.yarnpkg.com/string_decoder/-/string_decoder-1.3.0.tgz#42f114594a46cf1a8e30b0a84f56c78c3edac21e"
@@ -6876,9 +6801,9 @@ tar@^6.0.2:
     yallist "^4.0.0"
 
 term-size@^2.1.0:
-  version "2.2.0"
-  resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.0.tgz#1f16adedfe9bdc18800e1776821734086fcc6753"
-  integrity sha512-a6sumDlzyHVJWb8+YofY4TW112G6p2FCPEAFk+59gIYHv3XHRhm9ltVQ9kli4hNWeQBwSpe8cRN25x0ROunMOw==
+  version "2.2.1"
+  resolved "https://registry.yarnpkg.com/term-size/-/term-size-2.2.1.tgz#2a6a54840432c2fb6320fea0f415531e90189f54"
+  integrity sha512-wK0Ri4fOGjv/XPy8SBHZChl8CM7uMc5VML7SqiQ0zG7+J5Vr+RMQDoHa2CNT6KHUnTGIXH34UDMkPzAUyapBZg==
 
 terminal-link@^2.0.0:
   version "2.1.1"
@@ -6926,9 +6851,9 @@ through@2, through@^2.3.6, through@^2.3.8:
   integrity sha1-DdTJ/6q8NXlgsbckEV1+Doai4fU=
 
 timers-browserify@^2.0.4:
-  version "2.0.11"
-  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.11.tgz#800b1f3eee272e5bc53ee465a04d0e804c31211f"
-  integrity sha512-60aV6sgJ5YEbzUdn9c8kYGIqOubPoUdqQCul3SBAsRCZ40s6Y5cMcrW4dt3/k/EsbLVJNl9n6Vz3fTc+k2GeKQ==
+  version "2.0.12"
+  resolved "https://registry.yarnpkg.com/timers-browserify/-/timers-browserify-2.0.12.tgz#44a45c11fbf407f34f97bccd1577c652361b00ee"
+  integrity sha512-9phl76Cqm6FhSX9Xe1ZUAMLtm1BLkKj2Qd5ApyWkXzsMRaA7dgr81kf4wJmQf/hAvg8EEyJxDo3du/0KlhPiKQ==
   dependencies:
     setimmediate "^1.0.4"
 
@@ -7086,9 +7011,9 @@ typedarray@^0.0.6:
   integrity sha1-hnrHTjhkGHsdPUfZlqeOxciDB3c=
 
 typescript@^4.0.3:
-  version "4.0.3"
-  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.3.tgz#153bbd468ef07725c1df9c77e8b453f8d36abba5"
-  integrity sha512-tEu6DGxGgRJPb/mVPIZ48e69xCn2yRmCgYmDugAVwmJ6o+0u1RI18eO7E7WBTLYLaEVVOhwQmcdhQHweux/WPg==
+  version "4.0.5"
+  resolved "https://registry.yarnpkg.com/typescript/-/typescript-4.0.5.tgz#ae9dddfd1069f1cb5beb3ef3b2170dd7c1332389"
+  integrity sha512-ywmr/VrTVCmNTJ6iV2LwIrfG1P+lv6luD8sUJs+2eI9NLGigaN+nUQc13iHqisq7bra9lnmUSYqbJvegraBOPQ==
 
 unicode-canonical-property-names-ecmascript@^1.0.4:
   version "1.0.4"


### PR DESCRIPTION
React 17 was being installed as a dependency, but when using it on the `composer`, that still uses React 16, React was complaining about using different React versions:

![image](https://user-images.githubusercontent.com/76673/98576522-8d97f000-22b2-11eb-9142-21cdcf587b23.png)

![image](https://user-images.githubusercontent.com/76673/98576566-a1dbed00-22b2-11eb-9776-836d34706fd6.png)
